### PR TITLE
security: Implement RBAC and network policies for microservices

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
   - doctor-service.yaml
   - frontend.yaml
   - frontend-ingress.yaml
+  - rbac.yaml
+  - network-policies.yaml
 
 namespace: pethospital-dev

--- a/k8s/base/network-policies.yaml
+++ b/k8s/base/network-policies.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pet-service-netpol
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: pet-service
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-nginx
+    ports:
+    - protocol: TCP
+      port: 3000
+  egress:
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hospital-service-netpol
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: hospital-service
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-nginx
+    ports:
+    - protocol: TCP
+      port: 3000
+  egress:
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: doctor-service-netpol
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: doctor-service
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-nginx
+    ports:
+    - protocol: TCP
+      port: 3000
+  egress:
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443

--- a/k8s/base/rbac.yaml
+++ b/k8s/base/rbac.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pet-service-sa
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hospital-service-sa
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: doctor-service-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: service-reader
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pet-service-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: pet-service-sa
+  namespace: default
+roleRef:
+  kind: Role
+  name: service-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hospital-service-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: hospital-service-sa
+  namespace: default
+roleRef:
+  kind: Role
+  name: service-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: doctor-service-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: doctor-service-sa
+  namespace: default
+roleRef:
+  kind: Role
+  name: service-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Add dedicated service accounts for each microservice
- Implement least-privilege RBAC with service-reader role
- Add network policies for service isolation
- Restrict ingress traffic to frontend and ingress controller only
- Allow egress for DNS resolution and HTTPS