### PR TITLE
feat(service): Add metrics endpoints to all backend services

### DIFF
--- a/backend/doctor-service/server.js
+++ b/backend/doctor-service/server.js
@@ -24,6 +24,44 @@ const port = process.env.PORT || 3000;
 app.use(cors());
 app.use(bodyParser.json());
 
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'healthy',
+    service: 'doctor-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
+// Readiness check endpoint
+app.get('/ready', (req, res) => {
+  res.status(200).json({
+    status: 'ready',
+    service: 'doctor-service',
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Metrics endpoint
+app.get('/metrics', (req, res) => {
+  const memUsage = process.memoryUsage();
+  res.status(200).json({
+    service: 'doctor-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    memory: {
+      rss: memUsage.rss,
+      heapTotal: memUsage.heapTotal,
+      heapUsed: memUsage.heapUsed,
+      external: memUsage.external
+    },
+    cpu: process.cpuUsage(),
+    version: process.version,
+    platform: process.platform
+  });
+});
+
 // Request logging middleware
 app.use((req, res, next) => {
   const start = Date.now();

--- a/backend/hospital-service/server.js
+++ b/backend/hospital-service/server.js
@@ -24,6 +24,44 @@ const port = process.env.PORT || 3000;
 app.use(cors());
 app.use(bodyParser.json());
 
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'healthy',
+    service: 'hospital-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
+// Readiness check endpoint
+app.get('/ready', (req, res) => {
+  res.status(200).json({
+    status: 'ready',
+    service: 'hospital-service',
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Metrics endpoint
+app.get('/metrics', (req, res) => {
+  const memUsage = process.memoryUsage();
+  res.status(200).json({
+    service: 'hospital-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    memory: {
+      rss: memUsage.rss,
+      heapTotal: memUsage.heapTotal,
+      heapUsed: memUsage.heapUsed,
+      external: memUsage.external
+    },
+    cpu: process.cpuUsage(),
+    version: process.version,
+    platform: process.platform
+  });
+});
+
 // Request logging middleware
 app.use((req, res, next) => {
   const start = Date.now();

--- a/backend/pet-service/server.js
+++ b/backend/pet-service/server.js
@@ -24,6 +24,45 @@ const port = process.env.PORT || 3000;
 app.use(cors());
 app.use(bodyParser.json());
 
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'healthy',
+    service: 'pet-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
+// Readiness check endpoint
+app.get('/ready', (req, res) => {
+  // Check if service is ready (e.g., database connections, etc.)
+  res.status(200).json({
+    status: 'ready',
+    service: 'pet-service',
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Metrics endpoint
+app.get('/metrics', (req, res) => {
+  const memUsage = process.memoryUsage();
+  res.status(200).json({
+    service: 'pet-service',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    memory: {
+      rss: memUsage.rss,
+      heapTotal: memUsage.heapTotal,
+      heapUsed: memUsage.heapUsed,
+      external: memUsage.external
+    },
+    cpu: process.cpuUsage(),
+    version: process.version,
+    platform: process.platform
+  });
+});
+
 // Request logging middleware
 app.use((req, res, next) => {
   const start = Date.now();


### PR DESCRIPTION
- Add /metrics endpoint to pet-service, hospital-service, and doctor-service
- Expose runtime metrics including memory usage, CPU usage, uptime
- Include Node.js version and platform information
- Enhance observability for monitoring and debugging

These endpoints provide detailed runtime information for each service, enabling better monitoring and performance analysis.