### PR TITLE
Update ingress rules for new service endpoints

### DIFF
--- a/k8s/base/frontend-ingress.yaml
+++ b/k8s/base/frontend-ingress.yaml
@@ -11,6 +11,27 @@ spec:
   rules:
     - http:
         paths:
+          - path: /api/pets
+            pathType: Prefix
+            backend:
+              service:
+                name: pet-service
+                port:
+                  number: 3000
+          - path: /api/doctors
+            pathType: Prefix
+            backend:
+              service:
+                name: doctor-service
+                port:
+                  number: 3000
+          - path: /api/hospitals
+            pathType: Prefix
+            backend:
+              service:
+                name: hospital-service
+                port:
+                  number: 3000
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
This PR updates the ingress configuration to expose the backend service endpoints:

## Changes Made
- Added API route  → 
- Added API route  →   
- Added API route  → 
- Maintained existing frontend route  →  as fallback

## Benefits
- Enables direct access to backend services through the ALB
- Provides proper API routing for microservices architecture
- Maintains backward compatibility with existing frontend routing

## Testing
The ingress rules are ordered with specific API paths first, followed by the catch-all frontend route to ensure proper routing precedence.